### PR TITLE
Change App Header Background Color to White Smoke

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@
 }
 
 .App-header {
-    background-color: #E2e5e5;
+    background-color: whitesmoke;
     min-height: 100vh;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Old background color was incorrect. Changed to proper color (`white smoke`) for CDR and general future purposes.